### PR TITLE
docs: user: hugepages: add details on K8S versions

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -690,7 +690,9 @@ configured [default requests](reference/operator_parameters.md#kubernetes-resour
 
 ### HugePages support
 
-The operator supports [HugePages](https://www.postgresql.org/docs/15/kernel-resources.html#LINUX-HUGEPAGES).
+The operator supports [HugePages](https://www.postgresql.org/docs/15/kernel-resources.html#LINUX-HUGEPAGES)
+on Kubernetes 1.19 and 1.18 with the `HugePageStorageMediumSize` Feature Gate enabled.
+
 To enable HugePages, set the matching resource requests and/or limits in the manifest:
 
 ```yaml


### PR DESCRIPTION
HugePageStorageMediumSize was added as a Feature Gate in 1.18, enabled by default in 1.19, and promoted to GA in 1.22

I'd like to see your PR pushed upstream, this just adds a bit more detail to it.